### PR TITLE
refactor: simplify notification time matching with exact minute preci…

### DIFF
--- a/src/main/java/saomath/checkusserver/notification/service/NotificationTargetServiceImpl.java
+++ b/src/main/java/saomath/checkusserver/notification/service/NotificationTargetServiceImpl.java
@@ -29,12 +29,12 @@ public class NotificationTargetServiceImpl implements NotificationTargetService 
     
     @Override
     public List<StudyTarget> getStudyTargetsForTime(LocalDateTime targetTime) {
-        // 대상 시간의 공부 일정 조회 (분 단위까지만 비교)
+        // 정확히 해당 분(minute)의 공부 일정만 조회 (초/나노초는 0으로 정규화)
+        LocalDateTime exactMinute = targetTime.withSecond(0).withNano(0);
         List<AssignedStudyTime> studyTimes = assignedStudyTimeRepository
-            .findByStartTimeBetween(
-                targetTime.withSecond(0).withNano(0),
-                targetTime.withSecond(59).withNano(999999999)
-            );
+            .findByStartTimeWithDetails(exactMinute);
+        
+        log.debug("공부 일정 대상자 조회 - 대상시간: {}, 조회결과: {}건", exactMinute, studyTimes.size());
         
         return studyTimes.stream()
             .map(this::convertToStudyTarget)
@@ -57,12 +57,10 @@ public class NotificationTargetServiceImpl implements NotificationTargetService 
     
     @Override
     public List<NoShowTarget> getNoShowTargets(LocalDateTime startTime) {
-        // 시작 시간 기준으로 공부 일정 조회
+        // 시작 시간 기준으로 공부 일정 조회 (정확한 시간 매칭)
+        LocalDateTime exactMinute = startTime.withSecond(0).withNano(0);
         List<AssignedStudyTime> studyTimes = assignedStudyTimeRepository
-            .findByStartTimeBetween(
-                startTime.withSecond(0).withNano(0),
-                startTime.withSecond(59).withNano(999999999)
-            );
+            .findByStartTimeWithDetails(exactMinute);
         
         List<NoShowTarget> noShowTargets = new ArrayList<>();
         

--- a/src/main/java/saomath/checkusserver/repository/AssignedStudyTimeRepository.java
+++ b/src/main/java/saomath/checkusserver/repository/AssignedStudyTimeRepository.java
@@ -63,6 +63,18 @@ public interface AssignedStudyTimeRepository extends JpaRepository<AssignedStudy
     
     List<AssignedStudyTime> findByStartTimeBetween(LocalDateTime start, LocalDateTime end);
     
+    // 정확한 시간 매칭 (알림용)
+    List<AssignedStudyTime> findByStartTime(LocalDateTime startTime);
+    
+    // 정확한 시간 매칭 - 연관 엔티티와 함께 조회 (알림용)
+    @Query("SELECT ast FROM AssignedStudyTime ast " +
+           "LEFT JOIN FETCH ast.student " +
+           "LEFT JOIN FETCH ast.activity " +
+           "LEFT JOIN FETCH ast.assignedByUser " +
+           "WHERE ast.startTime = :startTime " +
+           "ORDER BY ast.startTime")
+    List<AssignedStudyTime> findByStartTimeWithDetails(@Param("startTime") LocalDateTime startTime);
+    
     // 전체 조회용 - 연관 엔티티와 함께 조회
     @Query("SELECT ast FROM AssignedStudyTime ast " +
            "LEFT JOIN FETCH ast.student " +


### PR DESCRIPTION
…sion

- Add findByStartTime() and findByStartTimeWithDetails() to repository
- Replace complex time range queries with exact time matching
- Normalize all input times to exact minute (second=0, nano=0)
- Remove unnecessary time range calculations and edge cases
- Add comprehensive tests for exact time matching behavior

This completely eliminates duplicate notifications (11min + 10min before) by ensuring each assigned study time matches exactly once per minute.