### PR TITLE
fix: Set server timezone to UTC and fix Discord notification time dis…

### DIFF
--- a/src/main/java/saomath/checkusserver/config/JacksonConfig.java
+++ b/src/main/java/saomath/checkusserver/config/JacksonConfig.java
@@ -1,0 +1,33 @@
+package saomath.checkusserver.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+@Configuration
+public class JacksonConfig {
+    
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        JavaTimeModule module = new JavaTimeModule();
+        module.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(FORMATTER));
+        module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(FORMATTER));
+        
+        return new ObjectMapper()
+                .registerModule(module)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+}

--- a/src/main/java/saomath/checkusserver/config/TimeZoneConfig.java
+++ b/src/main/java/saomath/checkusserver/config/TimeZoneConfig.java
@@ -1,0 +1,16 @@
+package saomath.checkusserver.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class TimeZoneConfig {
+    
+    @PostConstruct
+    public void init() {
+        // 애플리케이션 전역 시간대를 UTC로 설정
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+}

--- a/src/main/java/saomath/checkusserver/notification/event/NotificationEventListener.java
+++ b/src/main/java/saomath/checkusserver/notification/event/NotificationEventListener.java
@@ -46,7 +46,7 @@ public class NotificationEventListener {
             // 알림 변수 설정
             Map<String, String> variables = new HashMap<>();
             variables.put("이름", event.getStudentName());
-            variables.put("입장시간", event.getEnterTime().format(TIME_FORMATTER));
+            variables.put("입장시간", event.getEnterTime().toString()); // ISO 형식으로 전달
             
             // 멀티채널로 학생에게 알림 전송
             notificationService.sendNotification(

--- a/src/main/java/saomath/checkusserver/util/DateTimeUtils.java
+++ b/src/main/java/saomath/checkusserver/util/DateTimeUtils.java
@@ -1,0 +1,29 @@
+package saomath.checkusserver.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeUtils {
+    
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final ZoneId UTC = ZoneId.of("UTC");
+    private static final DateTimeFormatter KST_FORMATTER = DateTimeFormatter.ofPattern("a h:mm").withZone(KST);
+    
+    /**
+     * UTC LocalDateTime을 한국 시간 문자열로 변환
+     */
+    public static String formatToKoreanTime(LocalDateTime utcDateTime) {
+        if (utcDateTime == null) return "";
+        ZonedDateTime utcZoned = utcDateTime.atZone(UTC);
+        return KST_FORMATTER.format(utcZoned);
+    }
+    
+    /**
+     * 현재 UTC 시간 반환
+     */
+    public static LocalDateTime nowUtc() {
+        return LocalDateTime.now(UTC);
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ spring:
       on-profile: prod
 
   datasource:
-    url: jdbc:mysql://${RDS_ENDPOINT}:3306/${RDS_DATABASE}?useSSL=true&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${RDS_ENDPOINT}:3306/${RDS_DATABASE}?useSSL=true&serverTimezone=UTC
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -26,6 +26,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc:
+          time_zone: UTC
 
   sql:
     init:

--- a/src/test/java/saomath/checkusserver/util/DateTimeUtilsTest.java
+++ b/src/test/java/saomath/checkusserver/util/DateTimeUtilsTest.java
@@ -1,0 +1,53 @@
+package saomath.checkusserver.util;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateTimeUtilsTest {
+    
+    @Test
+    void formatToKoreanTime_오전시간_정상변환() {
+        // Given: UTC 00:40 (한국시간 09:40)
+        LocalDateTime utcTime = LocalDateTime.of(2025, 6, 21, 0, 40);
+        
+        // When
+        String result = DateTimeUtils.formatToKoreanTime(utcTime);
+        
+        // Then
+        assertThat(result).isEqualTo("오전 9:40");
+    }
+    
+    @Test
+    void formatToKoreanTime_오후시간_정상변환() {
+        // Given: UTC 09:40 (한국시간 18:40)
+        LocalDateTime utcTime = LocalDateTime.of(2025, 6, 21, 9, 40);
+        
+        // When
+        String result = DateTimeUtils.formatToKoreanTime(utcTime);
+        
+        // Then
+        assertThat(result).isEqualTo("오후 6:40");
+    }
+    
+    @Test
+    void formatToKoreanTime_자정_정상변환() {
+        // Given: UTC 15:00 (한국시간 00:00)
+        LocalDateTime utcTime = LocalDateTime.of(2025, 6, 21, 15, 0);
+        
+        // When
+        String result = DateTimeUtils.formatToKoreanTime(utcTime);
+        
+        // Then
+        assertThat(result).isEqualTo("오전 12:00");
+    }
+    
+    @Test
+    void formatToKoreanTime_null입력시_빈문자열반환() {
+        // When
+        String result = DateTimeUtils.formatToKoreanTime(null);
+        
+        // Then
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
…play

- Add TimeZoneConfig to set JVM default timezone to UTC
- Add JacksonConfig for UTC serialization/deserialization
- Update DB connection to use UTC timezone
- Create DateTimeUtils for UTC to KST conversion
- Fix Discord notification to display Korean time correctly
- Add unit tests for time conversion